### PR TITLE
Create MechJeb2-dev-2.5.4.0-502.ckan

### DIFF
--- a/MechJeb2-dev/MechJeb2-dev-2.5.4.0-502.ckan
+++ b/MechJeb2-dev/MechJeb2-dev-2.5.4.0-502.ckan
@@ -1,0 +1,33 @@
+{
+    "spec_version": "v1.6",
+    "identifier": "MechJeb2-dev",
+    "ksp_version": "1.0",
+    "name": "MechJeb 2 - DEV RELEASE",
+    "abstract": "Anatid Robotics and Multiversal Mechatronics proudly presents the first flight assistant autopilot: MechJeb",
+    "author": "sarbian",
+    "license": "GPL-3.0",
+    "x_ci_version_base": "2.5.4.0",
+    "provides": [
+        "MechJeb2"
+    ],
+    "conflicts": [
+        {
+            "name": "MechJeb2"
+        }
+    ],
+    "install": [
+        {
+            "find": "MechJeb2",
+            "install_to": "GameData"
+        }
+    ],
+    "resources": {
+        "ci": "https://ksp.sarbian.com/jenkins/job/MechJeb2-Dev/",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/124336",
+        "repository": "https://github.com/MuMech/MechJeb2/"
+    },
+    "version": "2.5.4.0-502",
+    "download": "https://ksp.sarbian.com/jenkins/job/MechJeb2-Dev/lastStableBuild/artifact/MechJeb2-2.5.4.0-502.zip",
+    "download_size": 3009009,
+    "x_generated_by": "netkan"
+}


### PR DESCRIPTION
Adds the latest Mechjeb2-dev build using the updated [MechJeb2-dev.netkan](https://github.com/KSP-CKAN/NetKAN-dev/pull/13)
